### PR TITLE
カレンダー課題提出

### DIFF
--- a/python/calendar.py
+++ b/python/calendar.py
@@ -1,9 +1,6 @@
 import sys
 import datetime
 
-# 各月の日数（0はインデックス調整用）
-LAST_DAYS = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-
 # 現在の年を取得
 today = datetime.date.today()
 year = today.year
@@ -32,7 +29,17 @@ print(title.center(20))
 # 月初日の曜日を取得(0=月曜日, 6=日曜日)
 first_date = datetime.date(year, month, 1)
 weekday = first_date.weekday()
-end_day = LAST_DAYS[month]
+
+if month == 12:
+    # 12月の場合は来月は「翌年の1月」
+    first_day_of_next_month = datetime.date(year + 1, 1, 1)
+else:
+    # それ以外は「同じ年の、月+1」
+    first_day_of_next_month = datetime.date(year, month + 1, 1)
+# 来月の1日から「1日」を引き算する
+last_day_of_this_month = first_day_of_next_month - datetime.timedelta(days=1)
+# 今月末日の日数を計算
+end_day = last_day_of_this_month.day
 
 # カレンダーの初週の空白の計算処理（48-49行目）に使う変数
 count = 0
@@ -45,8 +52,7 @@ for i in weekdays:
 print()
 
 # カレンダー初週の行において空白を作る処理
-for i in range(count):
-    print(f"{'  '}", end=" ")
+print("   " * count, end="")
 
 # 日付を表示（週が7日になったら改行）
 for i in range(1, end_day + 1):
@@ -56,4 +62,3 @@ for i in range(1, end_day + 1):
         print()
         count = 0
 print()
-

--- a/python/calendar.py
+++ b/python/calendar.py
@@ -1,0 +1,59 @@
+import sys
+import datetime
+
+# 各月の日数（0はインデックス調整用）
+LAST_DAYS = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+# 現在の年を取得
+today = datetime.date.today()
+year = today.year
+
+# コマンドライン引数の処理
+if len(sys.argv) == 3 and sys.argv[1] == "-m":
+    # -mオプションで月を指定した場合
+    try:
+        month = int(sys.argv[2])
+    except ValueError:
+        # 数値でない場合のエラー処理
+        print(f"{sys.argv[2]} is neither a month number (1..12) nor a name")
+        sys.exit()
+    if not (1 <= month <= 12):
+        # 月の範囲外の場合のエラー処理
+        print(f"{sys.argv[2]} is neither a month number (1..12) nor a name")
+        sys.exit()
+else:
+    # 引数がない場合は今月を使用
+    month = int(today.month)
+
+# タイトルの表示（中央揃え）
+title = f"{month}月 {year}"
+print(title.center(20))
+
+# 月初日の曜日を取得(0=月曜日, 6=日曜日)
+first_date = datetime.date(year, month, 1)
+weekday = first_date.weekday()
+end_day = LAST_DAYS[month]
+
+# カレンダーの初週の空白の計算処理（48-49行目）に使う変数
+count = 0
+count += weekday
+
+# 曜日のヘッダーを表示（月曜始まり）
+weekdays = ["月", "火", "水", "木", "金", "土", "日"]
+for i in weekdays:
+    print(f"{i:1} ", end="")
+print()
+
+# カレンダー初週の行において空白を作る処理
+for i in range(count):
+    print(f"{'  '}", end=" ")
+
+# 日付を表示（週が7日になったら改行）
+for i in range(1, end_day + 1):
+    print(f"{i:2}", end=" ")
+    count += 1
+    if count == 7:
+        print()
+        count = 0
+print()
+


### PR DESCRIPTION

## 変更内容
- `python/calendar.py`ファイルを追加

## 実装内容
`calendar.py`は以下の機能を実装しています：
- `python calendar.py`で現在の月のカレンダーを表示
- `-m`オプションで月を指定してカレンダーを表示（例：`python calendar.py -m 3`）
- 不正な値（1-12の範囲外、または数値以外）が指定された場合にエラーメッセージを表示

## 実行結果

### 引数なし（現在の月を表示）
```bash
$ python calendar.py
```
```
      1月 2026       
月 火 水 木 金 土 日 
          1  2  3  4 
 5  6  7  8  9 10 11 
12 13 14 15 16 17 18 
19 20 21 22 23 24 25 
26 27 28 29 30 31 
```

### -mオプションで3月を指定
```bash
$ python calendar.py -m 3
```
```
      3月 2026       
月 火 水 木 金 土 日 
                   1 
 2  3  4  5  6  7  8 
 9 10 11 12 13 14 15 
16 17 18 19 20 21 22 
23 24 25 26 27 28 29 
30 31 
```
